### PR TITLE
Remove leading slash when saving optimized image path

### DIFF
--- a/src/ImageOptimizerServiceProvider.php
+++ b/src/ImageOptimizerServiceProvider.php
@@ -4,6 +4,7 @@ namespace DaniHidayatX\ImageOptimizer;
 
 use Closure;
 use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Storage;
@@ -98,7 +99,7 @@ class ImageOptimizerServiceProvider extends PackageServiceProvider
         // Helper to check for Spatie component
         FileUpload::macro('isSpatieComponent', function () {
             return class_exists('\Filament\Forms\Components\SpatieMediaLibraryFileUpload') &&
-                   $this instanceof \Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+                   $this instanceof SpatieMediaLibraryFileUpload;
         });
 
         // Standard FileUpload Logic
@@ -157,7 +158,7 @@ class ImageOptimizerServiceProvider extends PackageServiceProvider
 
         // Spatie FileUpload Logic
         FileUpload::macro('processAndStoreSpatie', function (TemporaryUploadedFile $file, ?Model $record) {
-            /** @var \Filament\Forms\Components\SpatieMediaLibraryFileUpload $this */
+            /** @var SpatieMediaLibraryFileUpload $this */
             if (! $record || ! method_exists($record, 'addMedia')) {
                 return null;
             }

--- a/src/ImageOptimizerServiceProvider.php
+++ b/src/ImageOptimizerServiceProvider.php
@@ -142,12 +142,14 @@ class ImageOptimizerServiceProvider extends PackageServiceProvider
                     }
                 }
 
+                $path = ltrim($this->getDirectory() . '/' . $filename, '/');
+
                 Storage::disk($this->getDiskName())->put(
-                    $this->getDirectory() . '/' . $filename,
+                    $path,
                     $compressedImage
                 );
 
-                return $this->getDirectory() . '/' . $filename;
+                return $path;
             }
 
             return $this->storeUploadedFileToDisk($file);

--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -2,6 +2,10 @@
 
 namespace DaniHidayatX\ImageOptimizer;
 
+use Intervention\Image\Drivers\Imagick\Driver;
+use Intervention\Image\ImageManager;
+use Intervention\Image\ImageManagerStatic;
+
 class ImageProcessor
 {
     public static function process($source, array $settings): string
@@ -25,7 +29,7 @@ class ImageProcessor
 
     protected static function processV2($source, $format, $resize, $maxWidth, $maxHeight, $quality): string
     {
-        $image = \Intervention\Image\ImageManagerStatic::make($source);
+        $image = ImageManagerStatic::make($source);
 
         $shouldResize = false;
         $imageWidth = null;
@@ -66,10 +70,10 @@ class ImageProcessor
     protected static function processV3($source, $format, $resize, $maxWidth, $maxHeight, $quality): string
     {
         $driver = extension_loaded('imagick') && class_exists('\Intervention\Image\Drivers\Imagick\Driver')
-            ? new \Intervention\Image\Drivers\Imagick\Driver
+            ? new Driver
             : new \Intervention\Image\Drivers\Gd\Driver;
 
-        $manager = new \Intervention\Image\ImageManager($driver);
+        $manager = new ImageManager($driver);
         $image = $manager->read($source);
 
         $calcWidth = null;

--- a/tests/OptimizationTest.php
+++ b/tests/OptimizationTest.php
@@ -1,9 +1,15 @@
 <?php
 
+use Filament\Forms\ComponentContainer;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
+use Filament\Schemas\Schema;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Drivers\Imagick\Driver;
+use Intervention\Image\ImageManager;
+use Intervention\Image\ImageManagerStatic;
 use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 
@@ -30,13 +36,13 @@ class TestLivewireComponent extends Component implements HasForms
 function createTestImage($width, $height, $color, $path)
 {
     if (class_exists('Intervention\Image\ImageManagerStatic')) {
-        $img = \Intervention\Image\ImageManagerStatic::canvas($width, $height, $color);
+        $img = ImageManagerStatic::canvas($width, $height, $color);
         $img->save($path);
     } else {
         $driver = class_exists('Intervention\Image\Drivers\Imagick\Driver')
-            ? new \Intervention\Image\Drivers\Imagick\Driver
-            : new \Intervention\Image\Drivers\Gd\Driver;
-        $manager = new \Intervention\Image\ImageManager($driver);
+            ? new Driver
+            : new Intervention\Image\Drivers\Gd\Driver;
+        $manager = new ImageManager($driver);
         $img = $manager->create($width, $height)->fill($color);
         $img->save($path);
     }
@@ -45,12 +51,12 @@ function createTestImage($width, $height, $color, $path)
 function readTestImage($source)
 {
     if (class_exists('Intervention\Image\ImageManagerStatic')) {
-        return \Intervention\Image\ImageManagerStatic::make($source);
+        return ImageManagerStatic::make($source);
     } else {
         $driver = class_exists('Intervention\Image\Drivers\Imagick\Driver')
-            ? new \Intervention\Image\Drivers\Imagick\Driver
-            : new \Intervention\Image\Drivers\Gd\Driver;
-        $manager = new \Intervention\Image\ImageManager($driver);
+            ? new Driver
+            : new Intervention\Image\Drivers\Gd\Driver;
+        $manager = new ImageManager($driver);
 
         return $manager->read($source);
     }
@@ -66,7 +72,7 @@ function getTestImageMime($image)
 }
 
 beforeEach(function () {
-    $fs = new \Illuminate\Filesystem\Filesystem;
+    $fs = new Filesystem;
     $fs->cleanDirectory(__DIR__ . '/temp');
     if (! file_exists(__DIR__ . '/temp/livewire-tmp')) {
         mkdir(__DIR__ . '/temp/livewire-tmp', 0777, true);
@@ -78,9 +84,9 @@ function getConfiguredComponent(Closure $configure)
     $livewire = new TestLivewireComponent;
 
     // Adapt to breaking change in Filament v4/v5
-    $componentContainerClass = class_exists(\Filament\Forms\ComponentContainer::class)
-        ? \Filament\Forms\ComponentContainer::class
-        : \Filament\Schemas\Schema::class;
+    $componentContainerClass = class_exists(ComponentContainer::class)
+        ? ComponentContainer::class
+        : Schema::class;
 
     $container = $componentContainerClass::make($livewire)
         ->statePath('data')


### PR DESCRIPTION
The issue occurred because the logic assumed the $component->getDirectory() would always return a value or be manually called by the user. When ->directory() is not explicitly defined, the path concatenation resulted in a leading slash

Closes #5 