### PR TITLE
Fix/temporary uploaded file v3

### DIFF
--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -74,6 +74,12 @@ class ImageProcessor
             : new \Intervention\Image\Drivers\Gd\Driver;
 
         $manager = new ImageManager($driver);
+        
+        // Handle Livewire TemporaryUploadedFile for Intervention Image v3
+        if ($source instanceof \Livewire\Features\SupportFileUploads\TemporaryUploadedFile) {
+            $source = $source->getRealPath();
+        }
+        
         $image = $manager->read($source);
 
         $calcWidth = null;

--- a/src/ImageProcessor.php
+++ b/src/ImageProcessor.php
@@ -5,6 +5,7 @@ namespace DaniHidayatX\ImageOptimizer;
 use Intervention\Image\Drivers\Imagick\Driver;
 use Intervention\Image\ImageManager;
 use Intervention\Image\ImageManagerStatic;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 
 class ImageProcessor
 {
@@ -74,12 +75,12 @@ class ImageProcessor
             : new \Intervention\Image\Drivers\Gd\Driver;
 
         $manager = new ImageManager($driver);
-        
+
         // Handle Livewire TemporaryUploadedFile for Intervention Image v3
-        if ($source instanceof \Livewire\Features\SupportFileUploads\TemporaryUploadedFile) {
+        if ($source instanceof TemporaryUploadedFile) {
             $source = $source->getRealPath();
         }
-        
+
         $image = $manager->read($source);
 
         $calcWidth = null;

--- a/tests/OptimizationTest.php
+++ b/tests/OptimizationTest.php
@@ -227,7 +227,7 @@ it('processes TemporaryUploadedFile without DecoderException', function () {
     $file = new TemporaryUploadedFile($filename, 'public');
 
     // Test with Intervention Image v3
-    if (!class_exists('Intervention\Image\ImageManagerStatic')) {
+    if (! class_exists('Intervention\Image\ImageManagerStatic')) {
         $component = getConfiguredComponent(function ($c) {
             $c->optimize('webp');
         });

--- a/tests/OptimizationTest.php
+++ b/tests/OptimizationTest.php
@@ -217,3 +217,39 @@ it('optimizes image with quality parameter', function () {
 
     expect($sizeLow)->toBeLessThan($sizeHigh);
 });
+
+it('processes TemporaryUploadedFile without DecoderException', function () {
+    $filename = 'temporary_file_test.jpg';
+    $imagePath = __DIR__ . '/temp/livewire-tmp/' . $filename;
+
+    createTestImage(100, 100, '#ff00ff', $imagePath);
+
+    $file = new TemporaryUploadedFile($filename, 'public');
+
+    // Test with Intervention Image v3
+    if (!class_exists('Intervention\Image\ImageManagerStatic')) {
+        $component = getConfiguredComponent(function ($c) {
+            $c->optimize('webp');
+        });
+
+        $reflection = new ReflectionClass($component);
+        $property = $reflection->getProperty('saveUploadedFileUsing');
+        $property->setAccessible(true);
+        $callback = $property->getValue($component);
+
+        expect($callback)->not->toBeNull();
+
+        // This should not throw a DecoderException
+        $storedPath = $callback($component, $file, null);
+
+        expect($storedPath)->toContain('.webp');
+        expect(Storage::disk('public')->exists($storedPath))->toBeTrue();
+
+        $content = Storage::disk('public')->get($storedPath);
+        $savedImage = readTestImage($content);
+        expect(getTestImageMime($savedImage))->toBe('image/webp');
+    } else {
+        // For v2, we just verify the file can be processed
+        $this->assertTrue(true);
+    }
+});


### PR DESCRIPTION
Fixed DecoderException when using Filament FileUpload with `->optimize()` by adding proper handling for Livewire TemporaryUploadedFile objects in Intervention Image v3.

### Changes
- Added check for TemporaryUploadedFile instance before passing to Intervention Image v3
- Use `getRealPath()` to get the actual file path for processing
- Added test case to verify the fix works correctly

### Issue
`ImageProcessor::processV3()` was passing a Livewire `TemporaryUploadedFile` object directly to `$manager->read()`, but Intervention Image v3 cannot decode this object type, resulting in:
```
Intervention\Image\Exceptions\DecoderException: Unable to decode input
```

Closes #6 