### PR TITLE
Allow dynamic quality value in FileUpload optimize macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `image-optimizer` will be documented in this file.
 
+## v2.2.0 - 2026-04-24
+
+### What's Changed
+
+* Support dynamic quality using Closures in `optimize()` macro.
+* Official support for Laravel 13.
+* Added tests for dynamic quality evaluation.
+
 ## v2.1.2 - 2026-03-25
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-> [!NOTE]  
-> This package is a fork of [joshembling/image-optimizer](https://github.com/joshembling/image-optimizer), updated to support Filament v4 & v5 and Laravel 12.
+> This package is a fork of [joshembling/image-optimizer](https://github.com/joshembling/image-optimizer), updated to support Filament v4 & v5 and Laravel 12 & 13.
 
 # Optimize your Filament images before they reach your database.
 
@@ -35,7 +34,7 @@ You use the same components as you have been doing and have access to two additi
 
 ## Installation
 
-You can install the package via composer, which works with Filament v3.x & v4.x, and Laravel 10, 11 & 12:
+You can install the package via composer, which works with Filament v3.x, v4.x & v5.x, and Laravel 10, 11, 12 & 13:
 
 ```bash
 composer require danihidayatx/image-optimizer
@@ -49,7 +48,7 @@ You must be using [Filament v3.x, v4.x or v5.x](https://filamentphp.com/docs/pan
 
 | PHP | Laravel version | Filament version | Image Optimizer version |
 | ----- | ----- | -----| ----- |
-| ^8.2 | ^10.0, ^11.0, ^12.0 | ^3.2, ^4.0, ^5.0 | ^2.0 |
+| ^8.2 | ^10.0, ^11.0, ^12.0, ^13.0 | ^3.2, ^4.0, ^5.0 | ^2.2 |
 
 ### Server
 

--- a/src/ImageOptimizerServiceProvider.php
+++ b/src/ImageOptimizerServiceProvider.php
@@ -32,7 +32,7 @@ class ImageOptimizerServiceProvider extends PackageServiceProvider
     protected function registerMacros(): void
     {
         // Optimization Settings Macros
-        FileUpload::macro('optimize', function (string | Closure | null $format = 'webp', ?int $quality = null) {
+        FileUpload::macro('optimize', function (string | Closure | null $format = 'webp', int | Closure | null $quality = null) {
             $this->imageOptimization = $this->imageOptimization ?? [];
             $this->imageOptimization['format'] = $format;
             $this->imageOptimization['quality'] = $quality;

--- a/src/ImageOptimizerServiceProvider.php
+++ b/src/ImageOptimizerServiceProvider.php
@@ -110,7 +110,7 @@ class ImageOptimizerServiceProvider extends PackageServiceProvider
             $resize = $this->evaluate($settings['resize'] ?? null);
             $maxWidth = $this->evaluate($settings['max_width'] ?? null);
             $maxHeight = $this->evaluate($settings['max_height'] ?? null);
-            $quality = $settings['quality'] ?? null;
+            $quality = $this->evaluate($settings['quality'] ?? null);
 
             $filename = $this->getUploadedFileNameForStorage($file);
 
@@ -168,7 +168,7 @@ class ImageOptimizerServiceProvider extends PackageServiceProvider
             $resize = $this->evaluate($settings['resize'] ?? null);
             $maxWidth = $this->evaluate($settings['max_width'] ?? null);
             $maxHeight = $this->evaluate($settings['max_height'] ?? null);
-            $quality = $settings['quality'] ?? null;
+            $quality = $this->evaluate($settings['quality'] ?? null);
 
             $filename = $this->getUploadedFileNameForStorage($file);
             $content = $file->get();

--- a/tests/OptimizationTest.php
+++ b/tests/OptimizationTest.php
@@ -253,3 +253,35 @@ it('processes TemporaryUploadedFile without DecoderException', function () {
         $this->assertTrue(true);
     }
 });
+
+it('evaluates quality closure', function () {
+    $filename = 'closure_quality_test.jpg';
+    $imagePath = __DIR__ . '/temp/livewire-tmp/' . $filename;
+
+    createTestImage(100, 100, '#ff0000', $imagePath);
+
+    $file = new TemporaryUploadedFile($filename, 'public');
+
+    $component = getConfiguredComponent(function ($c) {
+        $c->optimize('jpg', fn () => 10);
+    });
+
+    $reflection = new ReflectionClass($component);
+    $property = $reflection->getProperty('saveUploadedFileUsing');
+    $property->setAccessible(true);
+    $callback = $property->getValue($component);
+
+    $storedPath = $callback($component, $file, null);
+
+    expect(Storage::disk('public')->exists($storedPath))->toBeTrue();
+    $sizeLow = Storage::disk('public')->size($storedPath);
+
+    $componentHigh = getConfiguredComponent(function ($c) {
+        $c->optimize('jpg', 100);
+    });
+    $callbackHigh = $property->getValue($componentHigh);
+    $storedPathHigh = $callbackHigh($componentHigh, $file, null);
+    $sizeHigh = Storage::disk('public')->size($storedPathHigh);
+
+    expect($sizeLow)->toBeLessThan($sizeHigh);
+});


### PR DESCRIPTION
## 🧩 What changed?

`FileUpload::macro('optimize')` method signature updated:

### Before
```php
string | Closure | null $format = 'webp', ?int $quality = null
```
### After
```php
string | Closure | null $format = 'webp', int | Closure | null $quality = null
```

### 🎯 Why this change?

Previously, the quality parameter only accepted a static integer or null.

This limited flexibility when trying to dynamically determine image quality based on form state or other field values.

With this update, quality can now also accept a Closure, enabling runtime resolution.

### ⚙️ Use cases

This change allows:

- Dynamic quality values using $get() in Filament forms
- Adjusting image quality based on:
  - Form inputs
  - File size
  - Conditional logic
  - External state
#### Example
```php
FileUpload::make('image')
    ->optimize(
        format: 'webp',
        quality: fn ($get) => $get('quality_setting')
    );
```